### PR TITLE
v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed unauhtorized behaviour in the UI. Solve #123
 - UI: When a PoP is added, it's possible to select though the available API versions.
 - Fix mongoid array problems.
+- Changed log file size to 64mb.
 
 ## 0.6.1
 - DNS as array. You can specify multiple DNS when a PoP is added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.1
+- VNF Manager uses the token and tenant_id. Is not using user/pass. This fixes the bug with Keystone v3.
+
 ## 0.7.0
 - Non admin users can use TeNOR. Using already created flavors inside Openstack.
 - Keystone v3 available.

--- a/hot-generator/routes/hot.rb
+++ b/hot-generator/routes/hot.rb
@@ -194,7 +194,6 @@ class HotGenerator < Sinatra::Application
 
 		# Validate JSON format
 		credentials_info = JSON.parse(request.body.read)
-		return 400, errors.to_json if errors
 
 		halt 400, 'Username not found' if credentials_info['username'].nil?
 		halt 400, 'Password not found' if credentials_info['password'].nil?

--- a/ns-provisioning/helpers/instantiation.rb
+++ b/ns-provisioning/helpers/instantiation.rb
@@ -138,14 +138,13 @@ module InstantiationHelper
             auth: {
                 url: {
                     keystone: popUrls[:keystone],
-                    orch: popUrls[:orch],
+                    orch: popUrls[:orch],# to remove
+                    heat: popUrls[:orch],
                     compute: popUrls[:compute]
                 },
-                tenant: pop_auth['tenant_name'],
-                username: pop_auth['username'],
+                tenant_id: pop_auth['tenant_id'],
                 token: pop_auth['token'],
-                password: pop_auth['password'],
-                is_admin: pop_auth['is_admin'],
+                is_admin: popUrls[:is_admin]
             },
             reserved_resources: @instance['resource_reservation'].find { |resources| resources[:pop_id] == pop_id },
             security_group_id: pop_auth['security_group_id'],

--- a/ns-provisioning/helpers/keystone_v3.rb
+++ b/ns-provisioning/helpers/keystone_v3.rb
@@ -65,11 +65,7 @@ module Authenticationv3Helper
             putRoleAdmin(popUrls[:keystone], pop_auth['tenant_id'], pop_auth['user_id'], token)
 
             logger.info 'Authentication using new user credentials.'
-            puts pop_auth['tenant_id']
-            puts pop_auth['username']
-            puts pop_auth['password']
             pop_auth['token'] = authentication_v3_ids(popUrls[:keystone], pop_auth['tenant_id'], pop_auth['username'], pop_auth['password'])
-            puts pop_auth['token']
             if pop_auth['token'].nil?
                 error = 'Authentication failed.'
                 logger.error error

--- a/ns-provisioning/helpers/ns.rb
+++ b/ns-provisioning/helpers/ns.rb
@@ -151,10 +151,15 @@ module NsProvisioner
                 logger.info "Removing user stack...."
                 stack_url = auth_info['stack_url']
                 logger.debug 'Removing user reserved stack...'
-                response, errors = delete_stack_with_wait(auth_info['stack_url'], token)
-                logger.error errors if errors
-                return 400, errors if errors
-                logger.info "User and tenant removed correctly."
+                if !auth_info['stack_url'].nil?
+                    response, errors = delete_stack_with_wait(auth_info['stack_url'], token)
+                    logger.error errors if errors
+                    return 400, errors if errors
+                    logger.info "User and tenant removed correctly."
+                else
+                    logger.info "No user and tenant to remove."
+                end
+
             end
             logger.info "REMOVED: User " + auth_info['user_id'].to_s + " and tenant '" + auth_info['tenant_id'].to_s
         end
@@ -320,13 +325,9 @@ module NsProvisioner
         if @instance['authentication'].size == 1
             logger.debug 'Only 1 PoP is defined'
             # generate networks for this PoP
-            puts  @instance['authentication']
             pop_auth = @instance['authentication'][0]
             tenant_token = pop_auth['token']
             popUrls = pop_auth['urls']
-            puts popUrls
-            puts pop_auth
-            puts tenant_token
 
             publicNetworkId, errors = publicNetworkId(popUrls[:neutron], tenant_token)
             return handleError(@instance, errors) if errors
@@ -350,7 +351,7 @@ module NsProvisioner
             stack_id = stack['stack']['id']
 
             #save stack_url in reserved resurces
-            puts "Saving reserved stack...."
+            logger.info "Saving reserved stack...."
             #network_stack = stack
             @resource_reservation = @instance['resource_reservation']
             resource_reservation = []

--- a/ns-provisioning/helpers/vim.rb
+++ b/ns-provisioning/helpers/vim.rb
@@ -18,59 +18,6 @@
 # @see NSProvisioner
 module VimHelper
 
-#deprecated
-    def openstackUserAuthentication(keystoneUrl, tenantName, user, password)
-        auth = { auth: { tenantName: tenantName, passwordCredentials: { username: user, password: password } } }
-
-        begin
-            response = RestClient.post keystoneUrl + '/tokens', auth.to_json, content_type: :json
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-        end
-
-        authentication, errors = parse_json(response)
-        return 400, errors if errors
-
-        authentication
-    end
-
-    #deprecated....
-    def openstackAdminAuthentication(keystoneUrl, tenantName, user, password)
-        auth = { auth: { tenantName: tenantName, passwordCredentials: { username: user, password: password } } }
-
-        begin
-            response = RestClient.post keystoneUrl + '/tokens', auth.to_json, content_type: :json
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-        end
-
-        authentication, errors = parse_json(response)
-        return 400, errors if errors
-
-        authentication['access']['token']['id']
-    end
-
-#deprecated
-    def openstackAuthentication(keystoneUrl, tenantId, user, password)
-        auth = { auth: { tenantId: tenantId, passwordCredentials: { username: user, password: password } } }
-
-        begin
-            response = RestClient.post keystoneUrl + '/tokens', auth.to_json, content_type: :json
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-            raise 500, e.response.body
-        end
-
-        authentication, errors = parse_json(response)
-        return 400, errors if errors
-
-        authentication['access']['token']['id']
-    end
-
-
     def deleteTenant(keystoneUrl, tenant_id, token)
         begin
             response = RestClient.delete keystoneUrl + '/tenants/' + tenant_id, :content_type => :json, :'X-Auth-Token' => token
@@ -92,74 +39,6 @@ module VimHelper
         nil
     end
 
-=begin
-#deprecated
-def createTenant(keystoneUrl, projectName, token)
-    project = { tenant: { description: 'Tenant created by TeNOR', enabled: true, name: projectName } }
-
-    begin
-        return getTenantId(keystoneUrl, tenantName, token)
-    rescue => e
-        begin
-            response = RestClient.post keystoneUrl + '/tenants', project.to_json, :content_type => :json, :'X-Auth-Token' => token
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-        end
-
-        project, errors = parse_json(response)
-        return 400, errors if errors
-
-        return project['tenant']['id']
-    end
-end
-
-#deprecated
-def createUser(keystoneUrl, projectId, userName, password, token)
-    user = { user: { email: userName + '@tenor-tnova.eu', enabled: true, name: userName, password: password, tenantId: projectId } }
-    user_id = getUserId(keystoneUrl, userName, token)
-    if user_id.nil?
-        begin
-            response = RestClient.post keystoneUrl + '/users', user.to_json, :content_type => :json, :'X-Auth-Token' => token
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-        end
-        user, errors = parse_json(response)
-        return 400, errors if errors
-
-        return user['user']['id']
-    else
-        return user_id
-    end
-end
-    def getTenantId(keystoneUrl, tenantName, token)
-        begin
-            response = RestClient.get keystoneUrl + '/tenants', :content_type => :json, :'X-Auth-Token' => token
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-        end
-
-        tenants, errors = parse_json(response)
-        tenant = tenants['tenants'].find { |tenant| tenant['name'] == tenantName }
-        return tenant['id'] unless tenant.nil?
-    end
-
-
-    def getUserId(keystoneUrl, username, token)
-        begin
-            response = RestClient.get keystoneUrl + '/users', :content_type => :json, :'X-Auth-Token' => token
-        rescue => e
-            logger.error e
-            logger.error e.response.body
-        end
-
-        users, errors = parse_json(response)
-        user = users['users'].find { |user| user['username'] == username }
-        return user['id'] unless user.nil?
-    end
-=end
     def getAdminRole(keystoneUrl, token)
         begin
             response = RestClient.get keystoneUrl + '/OS-KSADM/roles', :content_type => :json, :'X-Auth-Token' => token

--- a/ns-provisioning/routes/ns.rb
+++ b/ns-provisioning/routes/ns.rb
@@ -158,7 +158,11 @@ class Provisioner < NsProvisioning
                     callback_url = settings.manager + '/ns-instances/' + @instance['id']
 
                     next if vnf['vnfr_id'].nil?
-                    auth = { auth: { tenant: pop_auth['tenant_name'], username: pop_auth['username'], password: pop_auth['password'], url: { keystone: popUrls[:keystone] } }, callback_url: callback_url }
+                    # get token
+                    credentials, errors = authenticate(popUrls[:keystone], pop_auth['tenant_name'], pop_auth['username'], pop_auth['password'])
+                    logger.error errors if errors
+                    return if errors
+                    auth = { auth: { tenant_id: credentials[:tenant_id], user_id: credentials[:user_id], token: credentials[:token], url: { keystone: popUrls[:keystone] } }, callback_url: callback_url }
                     begin
                         response = RestClient.post settings.vnf_manager + '/vnf-provisioning/vnf-instances/' + vnf['vnfr_id'] + '/destroy', auth.to_json, content_type: :json
                     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH

--- a/vnf-provisioning/helpers/compute.rb
+++ b/vnf-provisioning/helpers/compute.rb
@@ -26,7 +26,7 @@ module ComputeHelper
             logger.error 'Already removed from the VIM.'
             return 404
         rescue => e
-          logge.error e
+          logger.error e
             #logger.error e.response
             return
             # halt e.response.code, e.response.body


### PR DESCRIPTION
VNF Manager uses the token and tenant_id. Is not using user/pass. This fixes the bug with Keystone v3.