### PR TITLE
Fix Vagrantfile to skip asking user to install dependencies.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
     cd ~
     git clone https://github.com/T-NOVA/TeNOR.git
     cd TeNOR/dependencies
-    ./install_dependencies.sh
+    echo -e "y\ny\ny\ny\n" | ./install_dependencies.sh
 
     cd ../
     #. ~/.rvm/scripts/rvm


### PR DESCRIPTION
When installing dependendies through vagrant, the script asks for the user if he wants to install the different modules, but Vagrant does not allow the user to answer. This fix defines an automatic "yes" response when the script asks for installing the dependencies.